### PR TITLE
Fix/online mode UUID

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: MineStats
-version: 6
+version: 7
 author: Afonso Batista
 main: org.rage.pluginstats.Main
 description: This plugin uploads to a dataBase the Stats of the players in a Minecraft Server.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
             <dependency>
                <groupId>org.spigotmc</groupId>
                <artifactId>spigot-api</artifactId>
-               <version>1.8.8-R0.1-SNAPSHOT</version>
+               <version>1.9.4-R0.1-SNAPSHOT</version>
                <scope>provided</scope>
            </dependency>
             <dependency>

--- a/src/org/rage/pluginstats/commands/MergeCommand.java
+++ b/src/org/rage/pluginstats/commands/MergeCommand.java
@@ -3,6 +3,7 @@ package org.rage.pluginstats.commands;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
@@ -172,9 +173,7 @@ public class MergeCommand implements CommandExecutor{
 							Updates.min(Stats.PLAYERSINCE.getQuery(), oldPlayer.getString(Stats.PLAYERSINCE.getQuery())),
 							Updates.set(Stats.TIMEPLAYED.getQuery(), mergeTimePlayed(recentPlayer.getString(Stats.TIMEPLAYED.getQuery()), oldPlayer.getString(Stats.TIMEPLAYED.getQuery()))),
 							Updates.addEachToSet(Stats.MEDALS.getQuery(), oldPlayer.getList(Stats.MEDALS.getQuery(), Document.class)),
-							Updates.addEachToSet(Stats.VERSIONS.getQuery(),oldPlayer.getList(Stats.VERSIONS.getQuery(), String.class)),
-							Updates.addEachToSet(Stats.BLOCKS.getQuery(), oldPlayer.getList(Stats.BLOCKS.getQuery(), Document.class)),
-							Updates.addEachToSet(Stats.MOBSKILLED.getQuery(), oldPlayer.getList(Stats.MOBSKILLED.getQuery(), Document.class))
+							Updates.addEachToSet(Stats.VERSIONS.getQuery(),oldPlayer.getList(Stats.VERSIONS.getQuery(), String.class))
 
 				)
 			);
@@ -199,6 +198,8 @@ public class MergeCommand implements CommandExecutor{
 	
 	private List<Document> mergeBlockData(List<Document> rpBlocks, List<Document> opBlocks) {
 		
+		int toRemove = -1;
+		
 		for(Document rDoc : rpBlocks) {
 			for(Document oDoc : opBlocks) {
 				if(rDoc.getString("bName").equals(oDoc.getString("bName"))) {
@@ -207,23 +208,42 @@ public class MergeCommand implements CommandExecutor{
 					
 					rDoc.put("bNumPlaced", placed);
 					rDoc.put("bNumDestroyed", destroyed);
+					
+					toRemove = opBlocks.indexOf(oDoc);
+					
+					continue;
 				}
 			}
+			
+			if(toRemove!=-1) opBlocks.remove(toRemove);
 		}
+		
+		rpBlocks.addAll(opBlocks);
 		
 		return rpBlocks;
 	}
 	
 	private List<Document> mergeMobData(List<Document> rpMobs, List<Document> opMobs) {
+		
+		int toRemove = -1;
+		
 		for(Document rDoc : rpMobs) {
 			for(Document oDoc : opMobs) {
 				if(rDoc.getString("mName").equals(oDoc.getString("mName"))) {
 					long killed = rDoc.getLong("mNumKilled") + oDoc.getLong("mNumKilled");
 					
 					rDoc.put("mNumKilled", killed);
+					
+					toRemove = opMobs.indexOf(oDoc);
+					
+					continue;
 				}
 			}
+			
+			if(toRemove!=-1) opMobs.remove(toRemove);
 		}
+				
+		rpMobs.addAll(opMobs);
 		
 		return rpMobs;
 	}

--- a/src/org/rage/pluginstats/commands/MergeCommand.java
+++ b/src/org/rage/pluginstats/commands/MergeCommand.java
@@ -215,7 +215,10 @@ public class MergeCommand implements CommandExecutor{
 				}
 			}
 			
-			if(toRemove!=-1) opBlocks.remove(toRemove);
+			if(toRemove!=-1) {
+				opBlocks.remove(toRemove);
+				toRemove = -1;
+			}
 		}
 		
 		rpBlocks.addAll(opBlocks);
@@ -240,7 +243,12 @@ public class MergeCommand implements CommandExecutor{
 				}
 			}
 			
-			if(toRemove!=-1) opMobs.remove(toRemove);
+			if(toRemove!=-1) {
+				opMobs.remove(toRemove);
+				toRemove = -1;
+			}
+			
+
 		}
 				
 		rpMobs.addAll(opMobs);

--- a/src/org/rage/pluginstats/listeners/ListenersController.java
+++ b/src/org/rage/pluginstats/listeners/ListenersController.java
@@ -93,9 +93,9 @@ public class ListenersController {
 	}
 	
 	public void placeBlock(Player player, Block block) {
-		if(block.getType().getId() > 0) {
+		if(block.getType().isBlock()) {
 			ServerPlayer pp = mongoDB.getPlayerStats(player);
-			pp.medalCheck(Medals.BUILDER, pp.placeBlock(block.getType().getId() ,block.getType().name()), player);
+			pp.medalCheck(Medals.BUILDER, pp.placeBlock(block.getType().name()), player);
 						
 			if(isRedstone(block))
 				pp.medalCheck(Medals.REDSTONENGINEER, pp.useRedstone(), player);
@@ -103,11 +103,11 @@ public class ListenersController {
 	}
 	
 	public void breakBlock(Player player, Block block) {
-		if(block.getType().getId() > 0) {
+		if(block.getType().isBlock()) {
 			int Ycord = player.getEyeLocation().getBlockY();
 			ServerPlayer pp = mongoDB.getPlayerStats(player);
 						
-			pp.medalCheck(Medals.DESTROYER, pp.breakBlock(block.getType().getId() ,block.getType().name()), player);
+			pp.medalCheck(Medals.DESTROYER, pp.breakBlock(block.getType().name()), player);
 			if(Ycord>=1 && Ycord<=63) pp.medalCheck(Medals.MINER, pp.mineBlock(), player);
 		}
 	}

--- a/src/org/rage/pluginstats/medals/Medal.java
+++ b/src/org/rage/pluginstats/medals/Medal.java
@@ -68,7 +68,7 @@ public class Medal {
 	
 	public void newMedalEffect(Player player) {
 		Location location = player.getLocation();
-		player.playSound(location, Sound.LEVEL_UP, level.getSoudLevel(), 2);
+		player.playSound(location, Sound.ENTITY_PLAYER_LEVELUP, level.getSoudLevel(), 2);
 		location.getWorld().playEffect(location, Effect.MOBSPAWNER_FLAMES, 2020);	
 	}
 	

--- a/src/org/rage/pluginstats/mongoDB/DataBase.java
+++ b/src/org/rage/pluginstats/mongoDB/DataBase.java
@@ -9,6 +9,7 @@ import org.rage.pluginstats.stats.Stats;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 
@@ -66,6 +67,10 @@ public class DataBase {
 	
 	public MongoCursor<Document> getAllPlayersByName(String playerName) {
 		return collection.find(new Document(Stats.NAME.getQuery(), playerName)).iterator();
+	}
+	
+	public FindIterable<Document> getAllPlayersByNameIt(String playerName) {
+		return collection.find(new Document(Stats.NAME.getQuery(), playerName));
 	}
 	
 	public void newDoc(Document playerDoc) {

--- a/src/org/rage/pluginstats/mongoDB/DataBaseManager.java
+++ b/src/org/rage/pluginstats/mongoDB/DataBaseManager.java
@@ -265,17 +265,15 @@ public class DataBaseManager {
 	public HashMap<String, Block> loadBlockStats(List<Document> blockStats) {
 		HashMap<String, Block> mapBlockStats = new HashMap<>();
 		
-		int bId;
 		String bName;
 		long bNumDestroyed,
 			 bNumPlaced;
 		
 		for(Document doc : blockStats) {
-			bId = doc.getInteger("bId");
 			bName = doc.getString("bName");
 			bNumDestroyed = doc.getLong("bNumDestroyed");
 			bNumPlaced = doc.getLong("bNumPlaced");
-			Block newBlock = new Block(bId, bName, bNumDestroyed, bNumPlaced);
+			Block newBlock = new Block(bName, bNumDestroyed, bNumPlaced);
 			
 			mapBlockStats.put(bName, newBlock);	
 		}

--- a/src/org/rage/pluginstats/mongoDB/DataBaseManager.java
+++ b/src/org/rage/pluginstats/mongoDB/DataBaseManager.java
@@ -26,6 +26,7 @@ import org.rage.pluginstats.stats.MobStats;
 import org.rage.pluginstats.stats.Stats;
 import org.rage.pluginstats.utils.Util;
 
+import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.model.Filters;
@@ -74,7 +75,20 @@ public class DataBaseManager {
 			
 			Document playerDoc = mongoDB.getPlayer(player.getUniqueId());
 			
-			if(playerDoc==null) playerDoc = newPlayer(player);
+			if(playerDoc==null) {
+				
+				playerDoc = getPlayerByName(player.getName());
+				
+				if(playerDoc!=null) {
+					serverManager.deleteFromHashMap((UUID) playerDoc.get(Stats.PLAYERID.getQuery()));
+					
+					updateStat(Filters.eq(Stats.PLAYERID.getQuery(), playerDoc.get(Stats.PLAYERID.getQuery())),
+							Updates.set(Stats.PLAYERID.getQuery(), player.getUniqueId()));
+					
+				}
+					
+				playerDoc = newPlayer(player);
+			}
 			
 			try {
 				downloadFromDataBase(pp, playerDoc);

--- a/src/org/rage/pluginstats/mongoDB/DataBaseManager.java
+++ b/src/org/rage/pluginstats/mongoDB/DataBaseManager.java
@@ -128,7 +128,7 @@ public class DataBaseManager {
 						playerDoc.getLong(Stats.MOBKILLS.getQuery()), playerDoc.getLong(Stats.ENDERDRAGONKILLS.getQuery()),
 						playerDoc.getLong(Stats.WITHERKILLS.getQuery()), playerDoc.getLong(Stats.FISHCAUGHT.getQuery()),
 						loadMobStats(playerDoc.getList(Stats.MOBSKILLED.getQuery(), Document.class))));
-				
+								
 				sp.setNumberOfVersions(playerDoc.getList(Stats.VERSIONS.getQuery(), String.class).size());
 				sp.setMetersTraveled(playerDoc.getLong(Stats.TRAVELLED.getQuery()));
 				sp.setTimePlayed(Long.parseLong(time[0])*3600+min*60);
@@ -140,7 +140,7 @@ public class DataBaseManager {
 				
 				sp.setPlayerSince(new SimpleDateFormat("dd/MM/yyyy").parse(playerDoc.getString(Stats.PLAYERSINCE.getQuery())));
 				sp.setLastLogin(new SimpleDateFormat("dd/MM/yyyy h:mm a").parse(playerDoc.getString(Stats.LASTLOGIN.getQuery())));
-				
+								
 				serverManager.newPlayerOnServer(sp);
 			} catch(NullPointerException e) {
 				for(Stats stat: Stats.values()) {
@@ -149,6 +149,7 @@ public class DataBaseManager {
 				}
 				mongoDB.getServerCollection().replaceOne(Filters.eq(Stats.PLAYERID.getQuery(), sp.getPlayerID()), playerDoc);
 				downloadFromDataBase(sp, playerDoc);
+				e.printStackTrace();
 			} catch(ParseException e) {
 				
 				String lastLogin = playerDoc.getString(Stats.LASTLOGIN.getQuery()).concat(" 12:00 AM"); 	
@@ -244,7 +245,7 @@ public class DataBaseManager {
 	
 	public HashMap<String, Mob> loadMobStats(List<Document> mobStats) {
 		HashMap<String, Mob> mapMobStats = new HashMap<>();
-		
+				
 		int mId;
 		String mName;
 		long mNumKilled;

--- a/src/org/rage/pluginstats/player/ServerPlayer.java
+++ b/src/org/rage/pluginstats/player/ServerPlayer.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 import org.bson.Document;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.rage.pluginstats.Main;
 import org.rage.pluginstats.medals.MLevel;
@@ -92,12 +93,12 @@ public class ServerPlayer extends PlayerProfile {
 		kilometer = 0;
 	}
 	
-	public long breakBlock(int blockId, String blockName) {
-		return blockStats.breakBlock(blockId, blockName);
+	public long breakBlock(String blockName) {
+		return blockStats.breakBlock(blockName);
 	}
 	
-	public long placeBlock(int blockId, String blockName) {
-		return blockStats.placeBlock(blockId, blockName);
+	public long placeBlock(String blockName) {
+		return blockStats.placeBlock(blockName);
 	}
 	
 	public long useRedstone() {

--- a/src/org/rage/pluginstats/stats/Block.java
+++ b/src/org/rage/pluginstats/stats/Block.java
@@ -8,36 +8,27 @@ import org.bson.Document;
  */
 public class Block {
 	private String bName;
-	private int bId;
 	private long bNumDestroyed,
 				 bNumPlaced;
 
 	
-	public Block(int bId, String bName, long bNumDestroyed, long bNumPlaced) {
-		this.bId = bId;
+	public Block(String bName, long bNumDestroyed, long bNumPlaced) {
 		this.bName = bName;
 		this.bNumDestroyed = bNumDestroyed;
 		this.bNumPlaced = bNumPlaced;
 
 	}
 	
-	public Block(int bId, String bName) {
-		this.bId = bId;
+	public Block(String bName) {
 		this.bName = bName;
 		this.bNumDestroyed = 0;
 		this.bNumPlaced = 0;
 	}
 	
 	public Document createBlockDocument() {
-		return new Document("bId", bId)
-				.append("bName", bName)
+		return new Document("bName", bName)
 				.append("bNumDestroyed", bNumDestroyed)
 				.append("bNumPlaced", bNumPlaced);
-
-	}
-	
-	public int getBlockId() {
-		return bId;
 	}
 	
 	public String getBlockName() {
@@ -50,10 +41,6 @@ public class Block {
 	
 	public long getBlockPlaced() {
 		return bNumPlaced;
-	}
-	
-	public void setBlockId(int bId) {
-		this.bId = bId;
 	}
 	
 	public void setBlockName(String bName) {

--- a/src/org/rage/pluginstats/stats/BlockStats.java
+++ b/src/org/rage/pluginstats/stats/BlockStats.java
@@ -67,11 +67,11 @@ public class BlockStats {
 		return minedBlocks;
 	}
 	
-	public long breakBlock(int blockId, String blockName) {
+	public long breakBlock(String blockName) {
 		Block blockDestroyed = getBlockStatsByName(blockName);
 		
 		if(blockDestroyed == null)
-			blockDestroyed = new Block(blockId, blockName);	
+			blockDestroyed = new Block(blockName);	
 		 
 		blockDestroyed.incNumBlocksDestroyed();
 		
@@ -80,11 +80,11 @@ public class BlockStats {
 		return blocksDestroyed++;
 	}
 	
-	public long placeBlock(int blockId, String blockName) {
+	public long placeBlock(String blockName) {
 		Block blockPlaced = getBlockStatsByName(blockName);
 		
 		if(blockPlaced == null)
-			blockPlaced = new Block(blockId, blockName);	
+			blockPlaced = new Block(blockName);	
 		 
 		blockPlaced.incNumBlocksPlaced();
 		

--- a/src/org/rage/pluginstats/stats/Stats.java
+++ b/src/org/rage/pluginstats/stats/Stats.java
@@ -35,7 +35,8 @@ public enum Stats {
 	TIMEPLAYED(19, "timePlayed", "Time Played", true, true, "0 Hr 0 Min"),
 	ONLINE(20, "online", "Is Online?", false, true),
 	MOBSKILLED(21, "mobsKilled", "Mobs Killed", false, true, Arrays.asList()),
-	BLOCKS(22, "blocks", "Blocks", false, true, Arrays.asList());
+	BLOCKS(22, "blocks", "Blocks", false, true, Arrays.asList()),
+	LINK(23, "link", "Link", false, false, "");
 
 	
 	private int index;


### PR DESCRIPTION
Fixed some errors introduced by the Online Mode on the server

- Players have different Ids on **Online** mode so it was being created duplicate players
- Merge command with errors when merging medals, blocks and mobs
- Removed deprecated Ids from block stats